### PR TITLE
added info on sites (dates, phenophases, elevation)

### DIFF
--- a/BinarySearchTree.cpp
+++ b/BinarySearchTree.cpp
@@ -55,7 +55,7 @@ void BinarySearchTree::addDataNode(string in_commonName, string in_sciName, stri
 			y->elevation.push_back(in_elevation);
 			y->siteID.push_back(in_siteID);
 			y->date.push_back(in_date);
-		}	
+		}
 	}
 	return;
 }
@@ -66,7 +66,7 @@ void BinarySearchTree::findDataNode(string commonName) {
 		cout << "data not found" << endl;
 	} else {
 		cout << "data information: " << endl;
-		printNode(x);
+		printNode(x, true);
 	}
 }
 
@@ -151,7 +151,7 @@ void BinarySearchTree::deleteDataNode(string commonName) {
 						}
 					}
 					delete x;
-					
+
 				} else if (x->right != NULL && x->left == NULL) {  // no nodes to left of root
 					if (replace->left == NULL) {
 						replace->parent = NULL;
@@ -176,7 +176,7 @@ void BinarySearchTree::deleteDataNode(string commonName) {
 						}
 					}
 					delete x;
-					
+
 				} else {  // nodes to both sides, replace w/ maximum node on left
 					replace = x->left;
 					if (replace->right == NULL) {
@@ -238,7 +238,7 @@ void BinarySearchTree::deleteAll(dataNode *node) {
 /*
  * Prototype: void BinarySearchTree::printTree(dataNode *node);
  * Description: This method does an in-order traversal of the tree in order
- * 		to print each node to the terminal. Handles empty-tree case (no data 
+ * 		to print each node to the terminal. Handles empty-tree case (no data
  * 		nodes).
 */
 
@@ -250,7 +250,7 @@ void BinarySearchTree::printTree(dataNode *node) {
 		if (node->left != NULL) {
 			printTree(node->left);
 		}
-		printNode(node);
+		printNode(node, false);
 		if (node->right != NULL) {
 			printTree(node->right);
 		}
@@ -258,15 +258,61 @@ void BinarySearchTree::printTree(dataNode *node) {
 	}
 }
 
-void BinarySearchTree::printNode(dataNode *node) {
+void BinarySearchTree::printNode(dataNode *node, bool lookUp) {
 	cout << "Common name: " << node->commonName << endl;
 	cout << "Scientific name: " << node->sciName << endl;
 	cout << "Number of records: " << node->count << endl;
 	cout << "Site ID(s): ";
 	for (unsigned int i = 0; i < (node->siteID).size()-1; i++) {
-		cout << node->siteID[i] << ", ";
+		cout << node->siteID[i]<<",";
 	} cout << node->siteID[node->siteID.size()-1] << endl;
+
+
+    if(lookUp){//only an option when the user has searched for a specimen by common name (not when printing entire tree)
+        std::string input = "blah";
+        while(input != "y" && input != "n"){//loop until user provides valid input
+            cout<<"Would you like more information on a site ID? (y)es or (n)o" <<endl;
+            std::getline(std::cin, input);
+        }
+
+        if(input =="y"){
+            std::string ID = " ";
+
+            while(ID.compare(" ") == 0){
+                cout<<"What is the site ID?"<<endl;
+                getline(std::cin, ID);
+            }
+
+            bool found = false;//indicates whether at least one with the same index has been found
+            for(unsigned int i=0; i < (node->siteID).size(); i++){
+               if(std::to_string(node->siteID[i]).compare(ID)== 0){//change to string to more easily handle invalid user input(e.g. string instead of int)
+                    if(!found){//first instance in vector
+                        cout<<"Site ID:" << node->siteID[i]<<endl;
+                        cout<<"Elevation:" <<node->elevation[i]<<endl;
+                        cout<<"----------"<<endl;
+                        found = true;
+                    }
+                    if(node->date[i].length() ==8){//different formatting depending on whether day of month was one character or two
+                        cout<<node->date[i].substr(0,2)<<"/"<<node->date[i].substr(2,2)<<"/"<<node->date[i].substr(4,4)<< ": " <<node->phenophase[i]<<endl;
+                    }
+                    else{
+                        cout<<node->date[i].substr(0,2)<<"/"<<node->date[i].substr(2,1)<<"/"<<node->date[i].substr(3,4)<<": " <<node->phenophase[i]<<endl;
+
+                    }
+
+                }
+            }
+
+            if(!found){
+                cout<<"Sorry, that ID could not be found" <<endl;
+            }
+
+            }
+        }
 }
+
+
+
 
 dataNode* BinarySearchTree::searchBSTree(dataNode *node, std::string in_commonName) {
 	if (node == NULL) {

--- a/BinarySearchTree.h
+++ b/BinarySearchTree.h
@@ -12,13 +12,13 @@ struct dataNode {
 	std::vector<int> siteID;
 	std::vector<std::string> date;
 	int count;  // number of times animal/plant has an entry in database
-	
+
 	dataNode *left;
 	dataNode *right;
 	dataNode *parent;
-	
+
 	dataNode(){};
-	
+
 	dataNode (std::string in_commonName, std::string in_sciName, std::string in_phenophase, int in_elevation, int in_siteID, std::string in_date, int count) {
 		commonName = in_commonName;
 		sciName = in_sciName;
@@ -41,13 +41,13 @@ class BinarySearchTree {
 		void addDataNode(std::string in_commonName, std::string in_sciName, std::string in_phenophase, int in_elevation, int in_siteID, std::string in_date, int count);
 		void findDataNode(std::string commonName);
 		void deleteDataNode(std::string commonName);
-		
+
 	protected:
-	
+
 	private:
 		void deleteAll(dataNode *node);  // postorder
 		void printTree(dataNode *node);
-		void printNode(dataNode *node);
+		void printNode(dataNode *node, bool lookUp);
 		dataNode* searchBSTree(dataNode *node, std::string commonName);
 		dataNode *root;
 };

--- a/RedBlackTree.cpp
+++ b/RedBlackTree.cpp
@@ -195,7 +195,7 @@ void RedBlackTree::printNode(rbNode *node, bool lookUp) {
                     }
                     else{
                         cout<<node->date[i].substr(0,2)<<"/"<<node->date[i].substr(2,1)<<"/"<<node->date[i].substr(3,4)<<": " <<node->phenophase[i]<<endl;
-                        cout<<"Phenophase:"<<node->phenophase[i]<<endl;
+
 
                     }
 

--- a/RedBlackTree.cpp
+++ b/RedBlackTree.cpp
@@ -31,10 +31,10 @@ void RedBlackTree::addDataNode(string in_commonName, string in_sciName, string i
 	rbNode *newNode = new rbNode (in_commonName, in_sciName, in_phenophase, in_elevation, in_siteID, in_date, count);
 	newNode->left = nil;
 	newNode->right = nil;
-	
+
 	rbNode *x = root;
 	rbNode *y = NULL;
-	
+
 	if (root == nil) {
 		root = newNode;
 		newNode->parent = NULL;
@@ -48,7 +48,7 @@ void RedBlackTree::addDataNode(string in_commonName, string in_sciName, string i
 				x = x->right;
 			}
 		}
-		
+
 		if (y != nil && y != NULL) {
 			if (newNode->commonName != y->commonName) {
 				newNode->parent = y;
@@ -65,10 +65,10 @@ void RedBlackTree::addDataNode(string in_commonName, string in_sciName, string i
 				y->elevation.push_back(in_elevation);
 				y->siteID.push_back(in_siteID);
 				y->date.push_back(in_date);
-			}	
+			}
 		}
 	}
-	
+
 	return;
 }
 
@@ -78,7 +78,7 @@ void RedBlackTree::findDataNode(string commonName) {
 		cout << "data not found" << endl;
 	} else {
 		cout << "data information: " << endl;
-		printNode(x);
+		printNode(x, true);
 	}
 	return;
 }
@@ -88,7 +88,7 @@ void RedBlackTree::deleteDataNode(string commonName) {
 	rbNode *y = z;
 	rbNode *x = nil;
 	bool yOrigColor = y->isRed;
-	
+
 	if (z->left == nil) {
 		x = z->right;
 		rbTransplant(z, z->right);  // todo
@@ -115,7 +115,7 @@ void RedBlackTree::deleteDataNode(string commonName) {
 		y->isRed = z->isRed;
 	}
 	delete z;
-	
+
 	if (!yOrigColor) {
 		rbDeleteFixup(x);
 	}
@@ -148,7 +148,7 @@ void RedBlackTree::printTree(rbNode *node) {
 		if (node->left != nil) {
 			printTree(node->left);
 		}
-		printNode(node);
+		printNode(node, false);
 		if (node->right != nil) {
 			printTree(node->right);
 		}
@@ -156,14 +156,58 @@ void RedBlackTree::printTree(rbNode *node) {
 	}
 }
 
-void RedBlackTree::printNode(rbNode *node) {
+void RedBlackTree::printNode(rbNode *node, bool lookUp) {
 	cout << "Common name: " << node->commonName << endl;
 	cout << "Scientific name: " << node->sciName << endl;
 	cout << "Number of records: " << node->count << endl;
 	cout << "Site ID(s): ";
 	for (unsigned int i = 0; i < (node->siteID).size()-1; i++) {
-		cout << node->siteID[i] << ", ";
+		cout << node->siteID[i]<<",";
 	} cout << node->siteID[node->siteID.size()-1] << endl;
+
+
+    if(lookUp){//only an option when the user has searched for a specimen by common name (not when printing entire tree)
+        std::string input = "blah";
+        while(input != "y" && input != "n"){//loop until user provides valid input
+            cout<<"Would you like more information on a site ID? (y)es or (n)o" <<endl;
+            std::getline(std::cin, input);
+        }
+
+        if(input =="y"){
+            std::string ID = " ";
+
+            while(ID.compare(" ") == 0){
+                cout<<"What is the site ID?"<<endl;
+                getline(std::cin, ID);
+            }
+
+            bool found = false;//indicates whether at least one with the same index has been found
+            for(unsigned int i=0; i < (node->siteID).size(); i++){
+               if(std::to_string(node->siteID[i]).compare(ID)== 0){//change to string to more easily handle invalid user input(e.g. string instead of int)
+                    if(!found){//first instance in vector
+                        cout<<"Site ID:" << node->siteID[i]<<endl;
+                        cout<<"Elevation:" <<node->elevation[i]<<endl;
+                        cout<<"----------"<<endl;
+                        found = true;
+                    }
+                    if(node->date[i].length() ==8){
+                        cout<<node->date[i].substr(0,2)<<"/"<<node->date[i].substr(2,2)<<"/"<<node->date[i].substr(4,4)<< ": " <<node->phenophase[i]<<endl;
+                    }
+                    else{
+                        cout<<node->date[i].substr(0,2)<<"/"<<node->date[i].substr(2,1)<<"/"<<node->date[i].substr(3,4)<<": " <<node->phenophase[i]<<endl;
+                        cout<<"Phenophase:"<<node->phenophase[i]<<endl;
+
+                    }
+
+                }
+            }
+
+            if(!found){
+                cout<<"Sorry, that ID could not be found" <<endl;
+            }
+
+            }
+        }
 }
 
 rbNode* RedBlackTree::searchRBTree(rbNode *node, std::string in_commonName) {
@@ -184,7 +228,7 @@ void RedBlackTree::rbAddFixup(rbNode *node) {
 	rbNode *uncle = NULL;
 	node->left = nil;
 	node->right = nil;
-	
+
 	while (node != root && node->parent->isRed) {
 			cout << "check" << endl;
 
@@ -240,7 +284,7 @@ void RedBlackTree::rbDeleteFixup(rbNode *node) {
 				leftRotate(node->parent);
 				w = node->parent->right;
 			}
-			
+
 			if (!w->left->isRed && !w->right->isRed) {
 				w->isRed = true;
 				node = node->parent;
@@ -258,7 +302,7 @@ void RedBlackTree::rbDeleteFixup(rbNode *node) {
 				node = root;
 			}
 		}
-		
+
 		else {
 			w = node->parent->right;
 			if (w->isRed) {
@@ -267,7 +311,7 @@ void RedBlackTree::rbDeleteFixup(rbNode *node) {
 				rightRotate(node->parent);
 				w = node->parent->left;
 			}
-			
+
 			if (!w->left->isRed && !w->right->isRed) {
 				w->isRed = true;
 				node = node->parent;
@@ -285,7 +329,7 @@ void RedBlackTree::rbDeleteFixup(rbNode *node) {
 				node = root;
 			}
 		}
-	} 
+	}
 	node->isRed = false;
 	return;
 }
@@ -328,7 +372,7 @@ void RedBlackTree::rightRotate(rbNode *x) {
 	x->left = y->right;
 	if (y->right != nil) {
 		y->right->parent = x;
-	} 
+	}
 	y->parent = x->parent;
 	if (x->parent == nil) {
 		root = y;

--- a/RedBlackTree.h
+++ b/RedBlackTree.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+
 struct rbNode {
 	std::string commonName;
 	std::string sciName;
@@ -12,14 +13,14 @@ struct rbNode {
 	std::vector<int> siteID;
 	std::vector<std::string> date;
 	int count;  // number of times animal/plant has an entry in database
-	
+
 	bool isRed;
 	rbNode *left;
 	rbNode *right;
 	rbNode *parent;
-	
+
 	rbNode(){};
-	
+
 	rbNode (std::string in_commonName, std::string in_sciName, std::string in_phenophase, int in_elevation, int in_siteID, std::string in_date, int count) {
 		commonName = in_commonName;
 		sciName = in_sciName;
@@ -42,14 +43,14 @@ class RedBlackTree {
 		void addDataNode(std::string in_commonName, std::string in_sciName, std::string in_phenophase, int in_elevation, int in_siteID, std::string in_date, int count);
 		void findDataNode(std::string commonName);
 		void deleteDataNode(std::string commonName);
-		
-		
+
+
 	protected:
-	
+
 	private:
 		void deleteAll(rbNode *node);  // postorder
 		void printTree(rbNode *node);
-		void printNode(rbNode *node);
+		void printNode(rbNode *node, bool lookUp);
 		rbNode* searchRBTree(rbNode *node, std::string commonName);
 		void rbAddFixup(rbNode *node);
 		void rbDeleteFixup(rbNode *node);


### PR DESCRIPTION
I noticed you had additional information in the nodes that you weren't printing. I added an option inside the search function to search for specific site IDs once a species has been found. If the user selects "yes" the elevation is printed and then the date and phenophase for every observation at the site ID is printed.

Here's an example run:

```
Please enter which type of tree you would like to build: (u)nbalanced or (r)ed-black, or (q)uit:
u
You have chosen: unbalanced BST
data.txt
*****Menu*****
1: print tree
2: add data
3: find data
4. delete data
5: exit to main menu
3
enter common name:
common lilac
data information:
Common name: common lilac
Scientific name: Syringa vulgaris
Number of records: 5
Site ID(s): 63,63,63,261,261
Would you like more information on a site ID? (y)es or (n)o
y
What is the site ID?
63
Site ID:63
Elevation:2136
----------
06/6/2014: Open flowers (lilac)
04/12/2014: Breaking leaf buds (lilac/honeysuckle)
04/26/2014: All leaf buds broken (lilac/honeysuckle)
```

I added the same functions to your RB tree, but I didn't get a chance to test it through the menu, so there might be some errors.
